### PR TITLE
Add support for miss sprites

### DIFF
--- a/CustomPortRifts/Patches/BeatmapAnimatorControllerPatch.cs
+++ b/CustomPortRifts/Patches/BeatmapAnimatorControllerPatch.cs
@@ -32,6 +32,20 @@ public static class BeatmapAnimatorControllerPatch {
             state.Image.sprite = state.Portrait.NormalSprites[0];
             return;
         }
+
+        float missDiff = fmodTimeCapsule.TrueBeatNumber - RRStageControllerPatch.last_miss;
+        if( missDiff < 1.0f && state.Portrait.HasMissSprites ){
+            int missFrame = Mathf.FloorToInt(missDiff * 31);
+            int missIndex = Mathf.Max(1, Mathf.FloorToInt(missFrame + 1) / 2);
+            if( state.Portrait.InVibe ) { //vibe miss
+                if(missIndex >= state.Portrait.VibePowerMissSprites.Length) missIndex = 0;
+                state.Image.sprite = state.Portrait.VibePowerMissSprites[missIndex];
+            } else {
+                if(missIndex >= state.Portrait.NormalMissSprites.Length) missIndex = 0;
+                state.Image.sprite = state.Portrait.NormalMissSprites[missIndex];
+            }
+            return;
+        }
         
         Sprite[] sprites = state.Portrait.ActiveSprites;
         float beat = Mathf.Max(fmodTimeCapsule.TrueBeatNumber, 0) % 1;

--- a/CustomPortRifts/Patches/BeatmapAnimatorControllerPatch.cs
+++ b/CustomPortRifts/Patches/BeatmapAnimatorControllerPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using Shared.PlayerData;
 using Shared.RhythmEngine;
 using UnityEngine;
@@ -33,20 +34,20 @@ public static class BeatmapAnimatorControllerPatch {
             return;
         }
 
-        float missDiff = fmodTimeCapsule.TrueBeatNumber - RRStageControllerPatch.last_miss;
-        if( missDiff < 1.0f && state.Portrait.HasMissSprites ){
-            int missFrame = Mathf.FloorToInt(missDiff * 31);
-            int missIndex = Mathf.Max(1, Mathf.FloorToInt(missFrame + 1) / 2);
-            if( state.Portrait.InVibe ) { //vibe miss
-                if(missIndex >= state.Portrait.VibePowerMissSprites.Length) missIndex = 0;
-                state.Image.sprite = state.Portrait.VibePowerMissSprites[missIndex];
-            } else {
-                if(missIndex >= state.Portrait.NormalMissSprites.Length) missIndex = 0;
-                state.Image.sprite = state.Portrait.NormalMissSprites[missIndex];
-            }
-            return;
-        }
+        bool vanillaMissBehaviour = true;
+        float missDiff = fmodTimeCapsule.TrueBeatNumber - (vanillaMissBehaviour ? RRStageControllerPatch.lastVanillaMiss : RRStageControllerPatch.lastMiss);
+        int missFrame = Mathf.FloorToInt(missDiff * 31);
+        int missIndex = Mathf.Max(1, Mathf.FloorToInt(missFrame + 1) / 2);
+        var missSpriteSet = state.Portrait.InVibe ? state.Portrait.VibePowerMissSprites : state.Portrait.NormalMissSprites;
+        if( missIndex >= missSpriteSet.Length ) missIndex = 0;
         
+        if( (vanillaMissBehaviour && !state.Portrait.InVibe) || !vanillaMissBehaviour ){
+            if( missDiff < 1.0f && state.Portrait.HasMissSprites ){
+                state.Image.sprite = missSpriteSet[missIndex];
+                return;
+            }
+        }
+
         Sprite[] sprites = state.Portrait.ActiveSprites;
         float beat = Mathf.Max(fmodTimeCapsule.TrueBeatNumber, 0) % 1;
         int frame = Mathf.FloorToInt(beat * 31); // portraits are animated at 31 fps, for some reason

--- a/CustomPortRifts/Patches/RRPortraitUiControllerPatch.cs
+++ b/CustomPortRifts/Patches/RRPortraitUiControllerPatch.cs
@@ -37,6 +37,13 @@ internal static class RRPortraitUiControllerPatch {
         Portrait.SetPerformanceLevel(performanceLevel);
     }
 
+    //vanilla miss behaivour
+    [HarmonyPatch("MissRecorded")]
+    [HarmonyPrefix]
+    public static void MissRecorded(){
+        RRStageControllerPatch.lastVanillaMiss = RRStageControllerPatch.lastMiss;        
+    }
+
     [HarmonyPatch("LoadCharacterPortrait")]
     [HarmonyPrefix]
     public static void LoadCharacterPortrait_Pre(

--- a/CustomPortRifts/Patches/RRStageControllerPatch.cs
+++ b/CustomPortRifts/Patches/RRStageControllerPatch.cs
@@ -16,11 +16,14 @@ using P = RRStageController;
 
 [HarmonyPatch(typeof(P))]
 internal static class RRStageControllerPatch {
+    public static float last_miss = 0;
+
     [HarmonyPatch(nameof(P.UnpackScenePayload))]
     [HarmonyPostfix]
     public async static void UnpackScenePayload(
         ScenePayload currentScenePayload
     ) {
+        last_miss = -1.0f;
         if(
             currentScenePayload is not RRCustomTrackScenePayload payload
             || !Config.General.Enabled.Value
@@ -96,6 +99,13 @@ internal static class RRStageControllerPatch {
         // bring that back (probably requires separating out the particles)
         Portrait.LevelId = levelId;
         Portrait.Loading = false;
+    }
+
+    [HarmonyPatch( nameof(P.HandleEnemyAttack) )]
+    [HarmonyPrefix]
+    public static void HandleEnemyAttack( P __instance ){
+        Shared.RhythmEngine.FmodTimeCapsule fmodTimeCapsule = __instance.BeatmapPlayer.FmodTimeCapsule;
+        last_miss = fmodTimeCapsule.TrueBeatNumber;
     }
 
     [HarmonyPatch(nameof(P.InitializeBackgroundRoutine))]

--- a/CustomPortRifts/Portrait.cs
+++ b/CustomPortRifts/Portrait.cs
@@ -23,6 +23,8 @@ public class Portrait {
     public Sprite[] PoorlySprites { get; private set; }
     public Sprite[] WellSprites { get; private set; }
     public Sprite[] VibePowerSprites { get; private set; }
+    public Sprite[] NormalMissSprites { get; private set; }
+    public Sprite[] VibePowerMissSprites { get; private set; }
     public Sprite[] ActiveSprites => Pose switch {
         PoseType.Normal => NormalSprites,
         PoseType.DoingPoorly => PoorlySprites,
@@ -31,16 +33,21 @@ public class Portrait {
         _ => NormalSprites // should never happen
     };
     public bool HasSprites => NormalSprites != null && NormalSprites.Length > 0;
-
+    public bool InVibe => Pose == PoseType.VibePower;
+    public bool HasMissSprites = false;
     public static void Reset() {
         Hero.NormalSprites = null;
         Hero.PoorlySprites = null;
         Hero.WellSprites = null;
         Hero.VibePowerSprites = null;
+        Hero.NormalMissSprites = null;
+        Hero.VibePowerMissSprites = null;
         Counterpart.NormalSprites = null;
         Counterpart.PoorlySprites = null;
         Counterpart.WellSprites = null;
         Counterpart.VibePowerSprites = null;
+        Counterpart.NormalMissSprites = null;
+        Counterpart.VibePowerMissSprites = null;
         Particles = null;
         Pose = PoseType.Normal;
         LevelId = "";
@@ -138,16 +145,21 @@ public class Portrait {
         var poorlySprites = await LoadPose(dir, "DoingPoorly");
         var wellSprites = await LoadPose(dir, "DoingWell");
         var vibePowerSprites = await LoadPose(dir, "VibePower");
+        var normalMissSprites = await LoadPose(dir, "NormalMiss");
+        var vibeMissSprites = await LoadPose(dir, "VibePowerMiss");
 
         normalSprites ??= wellSprites ?? poorlySprites ?? vibePowerSprites;
         wellSprites ??= normalSprites;
         poorlySprites ??= normalSprites;
         vibePowerSprites ??= wellSprites;
+        HasMissSprites = normalMissSprites != null; 
+        if( normalSprites.Length != 0 ) normalMissSprites ??= [normalSprites[0]];
+        if( normalMissSprites.Length != 0 ) vibeMissSprites ??= normalMissSprites;
 
-        SetSprites(normalSprites, poorlySprites, wellSprites, vibePowerSprites);
+        SetSprites(normalSprites, poorlySprites, wellSprites, vibePowerSprites, normalMissSprites, vibeMissSprites);
     }
 
-    public void SetSprites(Sprite[] normal, Sprite[] poorly, Sprite[] well, Sprite[] vibePower) {
+    public void SetSprites(Sprite[] normal, Sprite[] poorly, Sprite[] well, Sprite[] vibePower, Sprite[] normalMiss, Sprite[] vibePowerMiss ) {
         if(normal == null || normal.Length == 0) {
             throw new ArgumentException("Normal sprites must not be null or empty.", nameof(normal));
         }
@@ -164,9 +176,19 @@ public class Portrait {
             throw new ArgumentException("VibePower sprites must not be null or empty.", nameof(vibePower));
         }
 
+        if(normalMiss == null || normalMiss.Length == 0) {
+            throw new ArgumentException("NormalMiss sprites must not be null or empty.", nameof(normalMiss));
+        }
+
+        if(vibePowerMiss == null || vibePowerMiss.Length == 0) {
+            throw new ArgumentException("VibeMiss sprites must not be null or empty.", nameof(vibePowerMiss));
+        }
+
         NormalSprites = normal;
         PoorlySprites = poorly;
         WellSprites = well;
         VibePowerSprites = vibePower;
+        NormalMissSprites = normalMiss;
+        VibePowerMissSprites = vibePowerMiss;
     }
 }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To add custom portraits to your custom level, you do not need the mod installed,
 
 4. Inside the counterpart and/or hero folders, create subfolders called `Normal`, `DoingPoorly`, `DoingWell`, `VibePower`, `NormalMiss` and/or `VibePowerMiss`.
    > ℹ️ You don't need all of these, but at least one needs to have sprites inside of it for your custom portrait to load.
+   
    > ℹ️ `VibePowerMiss` won't be active unless you also have `NormalMiss` sprites
 
 5. Add your custom sprites as `.png` files inside the corresponding subfolders. To use an animation, upload each individual frame as a separate `.png` file.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ To add custom portraits to your custom level, you do not need the mod installed,
 
 3. Inside the new folder, create subfolders called `Hero` and/or `Counterpart` to add custom portraits for the left and right side, respectively.
 
-4. Inside the counterpart and/or hero folders, create subfolders called `Normal`, `DoingPoorly`, `DoingWell`, and/or `VibePower`.
+4. Inside the counterpart and/or hero folders, create subfolders called `Normal`, `DoingPoorly`, `DoingWell`, `VibePower`, `NormalMiss` and/or `VibePowerMiss`.
    > ℹ️ You don't need all of these, but at least one needs to have sprites inside of it for your custom portrait to load.
+   > ℹ️ `VibePowerMiss` won't be active unless you also have `NormalMiss` sprites
 
 5. Add your custom sprites as `.png` files inside the corresponding subfolders. To use an animation, upload each individual frame as a separate `.png` file.
    > ℹ️ The frames should be in alphabetical order. See below for more details regarding animations.
@@ -83,6 +84,10 @@ To add custom portraits to your custom level, you do not need the mod installed,
    >       heroic00.png
    >     VibePower/
    >       superheroic00.png
+   >     NormalMiss/
+   >       heroicmiss00.png
+   >     VibePowerMiss/
+   >       heroicvibemiss00.png
    > ```
 
 6. Publish your track to the Steam workshop using the official editor. Your portraits will automatically be attached.
@@ -98,6 +103,7 @@ That's it! If everything is properly configured, your track will have custom por
   - When the player has less than 3/10 HP: `DoingPoorly`, `Normal`, `DoingWell`, `VibePower`
   - When the player has 80+ combo: `DoingWell`, `Normal`, `DoingPoorly`, `VibePower`
   - All other times: `Normal`, `DoingWell`, `DoingPoorly`, `VibePower`
+- Missing overrides other animations for 1 beat whenever a note is missed, and plays either `VibePowerMiss` or `NormalMiss` depending on if vibe power is active or not.
 - Voicelines are silenced when custom portraits are active. Future versions may provide the ability to add custom voicelines.
 - To reduce load times, custom portraits are not reloaded when the map is replayed using the retry feature. If you modified your portrait, to see the changes you must first exit to the track selection menu and reopen the map.
 - To update (or delete) your portrait on the workshop, just edit (or delete) the contents of the `CustomPortRifts` folder and re-upload your track to the workshop.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ To add custom portraits to your custom level, you do not need the mod installed,
 
 4. Inside the counterpart and/or hero folders, create subfolders called `Normal`, `DoingPoorly`, `DoingWell`, `VibePower`, and/or `NormalMiss`.
    > ℹ️ You don't need all of these, but at least one needs to have sprites inside of it for your custom portrait to load.
-   > ℹ️ `VibePowerMiss` won't be active unless you also have `NormalMiss` sprites
 
 5. Add your custom sprites as `.png` files inside the corresponding subfolders. To use an animation, upload each individual frame as a separate `.png` file.
    > ℹ️ The frames should be in alphabetical order. See below for more details regarding animations.

--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ To add custom portraits to your custom level, you do not need the mod installed,
 
 3. Inside the new folder, create subfolders called `Hero` and/or `Counterpart` to add custom portraits for the left and right side, respectively.
 
-4. Inside the counterpart and/or hero folders, create subfolders called `Normal`, `DoingPoorly`, `DoingWell`, `VibePower`, `NormalMiss` and/or `VibePowerMiss`.
+4. Inside the counterpart and/or hero folders, create subfolders called `Normal`, `DoingPoorly`, `DoingWell`, `VibePower`, and/or `NormalMiss`.
    > ℹ️ You don't need all of these, but at least one needs to have sprites inside of it for your custom portrait to load.
-   > ℹ️ `VibePowerMiss` won't be active unless you also have `NormalMiss` sprites
 
 5. Add your custom sprites as `.png` files inside the corresponding subfolders. To use an animation, upload each individual frame as a separate `.png` file.
    > ℹ️ The frames should be in alphabetical order. See below for more details regarding animations.
@@ -86,8 +85,6 @@ To add custom portraits to your custom level, you do not need the mod installed,
    >       superheroic00.png
    >     NormalMiss/
    >       heroicmiss00.png
-   >     VibePowerMiss/
-   >       heroicvibemiss00.png
    > ```
 
 6. Publish your track to the Steam workshop using the official editor. Your portraits will automatically be attached.
@@ -103,7 +100,7 @@ That's it! If everything is properly configured, your track will have custom por
   - When the player has less than 3/10 HP: `DoingPoorly`, `Normal`, `DoingWell`, `VibePower`
   - When the player has 80+ combo: `DoingWell`, `Normal`, `DoingPoorly`, `VibePower`
   - All other times: `Normal`, `DoingWell`, `DoingPoorly`, `VibePower`
-- Missing overrides other animations for 1 beat whenever a note is missed, and plays either `VibePowerMiss` or `NormalMiss` depending on if vibe power is active or not.
+- Missing overrides other animations for 1 beat whenever a note is missed.
 - Voicelines are silenced when custom portraits are active. Future versions may provide the ability to add custom voicelines.
 - To reduce load times, custom portraits are not reloaded when the map is replayed using the retry feature. If you modified your portrait, to see the changes you must first exit to the track selection menu and reopen the map.
 - To update (or delete) your portrait on the workshop, just edit (or delete) the contents of the `CustomPortRifts` folder and re-upload your track to the workshop.


### PR DESCRIPTION
Not actually sure how long the miss animation takes normally, but I just defaulted to 1 beat and it seems close enough.

Also I did something a little hacky storing the beat of the last miss in a static float in RRStageControllerPatch, but I didn't really know where to put it as it'd probably be more of a hack to get a reference to the portraits in the stage controller.